### PR TITLE
Add tokens.js to files list so npm publish includes it

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
   },
   "files": [
     "LICENSE",
-    "index.js"
+    "index.js",
+    "tokens.js"
   ],
   "keywords": [
     "csrf",


### PR DESCRIPTION
Fixes https://github.com/birdofpreyru/csurf/issues/3 by adding `tokens.js` to the list of published files.