### PR TITLE
Use SHA256 instead of SHA1 so that security scanners don't complain about the algorithm

### DIFF
--- a/tokens.js
+++ b/tokens.js
@@ -25,14 +25,14 @@ const PLUS_GLOBAL_REGEXP = /\+/g;
 const SLASH_GLOBAL_REGEXP = /\//g;
 
 /**
- * Hash a string with SHA1, returning url-safe base64
+ * Hash a string with SHA256, returning url-safe base64
  * @param {string} str
  * @private
  */
 
 function hash(str) {
   return crypto
-    .createHash('sha1')
+    .createHash('sha256')
     .update(str, 'ascii')
     .digest('base64')
     .replace(PLUS_GLOBAL_REGEXP, '-')


### PR DESCRIPTION
I noticed that some security scanners, like for example Contrast, complain about sha1 used in this library flagging it as vulnerable. Let's use SHA256 instead of SHA1 to make the scanners happy.